### PR TITLE
Import fix in polymers.nim (ecs_chipmunk2d -> ecs_chipmunk2D)

### DIFF
--- a/polymers.nim
+++ b/polymers.nim
@@ -2,7 +2,7 @@ import console/[ecs_renderchar, ecs_consoleevents, ecs_mousebuttons]
 import network/[ecs_udp]
 import db/[ecs_db, ecs_db_threads]
 import misc/[ecs_killing, ecs_spawnafter, ecs_gridmap]
-import physics/[ecs_chipmunk2d]
+import physics/[ecs_chipmunk2D]
 import graphics/[ecs_opengl]
 
 export


### PR DESCRIPTION
Importing polymers fails on Nim 1.4.4 otherwise.